### PR TITLE
Clarification for kernel named functions

### DIFF
--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -469,13 +469,13 @@ The default behavior in SYCL applications is that all the definitions and
 declarations of the functions and methods are available to the SYCL compiler,
 in the same translation unit. When this is not the case, all the symbols that
 need to be exported to a SYCL library or from a C++ library to a SYCL
-application need to be defined using the macro: \texttt{SYCL_EXTERNAL}.
+application need to be defined using the macro \texttt{SYCL_EXTERNAL}.
 
 The \texttt{SYCL_EXTERNAL} macro will only be defined if the implementation
 supports offline linking. The macro is implementation-defined, but the following
 restrictions apply:
 \begin{itemize}
-\item \texttt{SYCL_EXTERNAL} can only be used on functions;
+\item \texttt{SYCL_EXTERNAL} can only be used on non-member functions;
 \item the function cannot use raw pointers as parameter or return types.
   Explicit pointer classes must be used instead;
 \item externally defined functions cannot call a

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -2207,9 +2207,13 @@ kernel arguments.
 
 A kernel can be defined as a named function object type. These function objects
 provide the same functionality as any C++ function object, with the
-restriction that they need to follow C++11 standard layout rules.
+restriction that they need to follow C++11 standard layout rules and that the
+\codeinline{operator()} function must be defined in the same translation unit as the
+host code that invokes it. (For example, if a kernel is invoked via
+\codeinline{parallel_for}, the definition of \codeinline{operator()} must be in the
+same translation unit as the call to \codeinline{parallel_for}.)
 The kernel function can be templated via templating the kernel
-function object type. The \tf{operator()} function may take different
+function object type. The \codeinline{operator()} function may take different
 parameters depending on the data accesses defined for the
 specific kernel. For details on restrictions for kernel naming,
 please refer to~\ref{sec:naming.kernels}.


### PR DESCRIPTION
Clarify that SYCL_EXTERNAL cannot be used for the "operator()" member
function of a kernel function object, or for any member function.

Also use consistent formatting for "operator()".  Most occurences used
\codeinline{}, but a few were using \tf{}.  Standardize on the former.