### PR TITLE
Clarify USM context restrictions

### DIFF
--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9958,14 +9958,13 @@ The characteristics of USM allocations are summarized in
 |                                 Another [code]#device#    | Optional  | Another [code]#device#| Optional
 |====
 
-Each USM memory allocation has an associated SYCL context, and any access to
-that memory must use the same context.  Specifically, any
-<<sycl-kernel-function>> that dereferences a pointer to a USM memory allocation
-must be submitted to a <<queue>> that was constructed with the same context
-that was used to allocate that USM memory.  The explicit memory operation
-<<command, commands>> that take USM pointers have a similar restriction.  (See
-<<subsec:explicitmemory>> for details.)  Violations of these requirements
-result in undefined behavior.
+Each USM allocation has an associated SYCL context, and any access to that
+memory must use the same context.  Specifically, any <<sycl-kernel-function>>
+that dereferences a pointer to a USM allocation must be submitted to a
+<<queue>> that was constructed with the same context that was used to allocate
+that memory.  The explicit memory operation <<command, commands>> that take USM
+pointers have a similar restriction.  (See <<subsec:explicitmemory>> for
+details.)  Violations of these requirements result in undefined behavior.
 
 [NOTE]
 ====
@@ -9984,7 +9983,7 @@ accessible to the device generally results in undefined behavior.  See
 Device allocations are used for explicitly managing device memory.
 Programmers directly allocate device memory and explicitly copy data
 between host memory and a device allocation. Device allocations are obtained
-through SYCL USM device allocation routines instead of system allocation
+through SYCL device USM allocation routines instead of system allocation
 routines like [code]#std::malloc# or {cpp} [code]#new#. Device
 allocations are not accessible on the host, but the pointer values remain
 consistent on account of Unified Addressing.  The size of device allocations
@@ -10112,7 +10111,8 @@ a@ Pointer is suitably aligned for an object of type [code]#T# or it is aligned
 SYCL defines an allocator class named [code]#usm_allocator# that satisfies the
 {cpp} named requirement [code]#Allocator#.  The [code]#AllocKind# template
 parameter can be either [code]#usm::alloc::host# or [code]#usm::alloc::shared#,
-causing the allocator to allocate either USM host or USM shared memory.
+causing the allocator to make either host USM allocations or shared USM
+allocations.
 
 [NOTE]
 ====
@@ -10195,8 +10195,8 @@ usm_allocator(const context &syclContext,
               const device &syclDevice,
               const property_list &propList = {})
 ----
-a@ Constructs a [code]#usm_allocator# instance that allocates USM memory for
-the provided context and device.
+a@ Constructs a [code]#usm_allocator# instance that allocates USM for the
+provided context and device.
 
 If [code]#AllocKind# is [code]#usm::alloc::host#, this constructor throws a
 synchronous [code]#exception# with the [code]#errc::feature_not_supported#
@@ -10223,19 +10223,16 @@ a@ Simplified constructor form where [code]#syclQueue# provides the
 
 |====
 
-SYCL also provides a number of free functions for allocating USM memory,
-similar to [code]#std::malloc#.
-
 ==== Device allocation functions
 
-The functions in <<table.usm.device.allocs>> allocate USM device memory.  On
-success, these functions return a pointer to the newly allocated memory, which
-must eventually be deallocated with [code]#sycl::free# in order to avoid a
-memory leak.  If there are not enough resources to allocate the requested
-memory, these functions return [code]#nullptr#.
+The functions in <<table.usm.device.allocs>> allocate device USM.  On success,
+these functions return a pointer to the newly allocated memory, which must
+eventually be deallocated with [code]#sycl::free# in order to avoid a memory
+leak.  If there are not enough resources to allocate the requested memory,
+these functions return [code]#nullptr#.
 
 [[table.usm.device.allocs]]
-.USM Device Memory Allocation Functions
+.Device USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Function @ Description
@@ -10247,14 +10244,14 @@ void* sycl::malloc_device(size_t numBytes,
                           const context& syclContext,
                           const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated memory on [code]#syclDevice# on
-success.  The allocation size is specified in bytes.  Throws a synchronous
-[code]#exception# with the [code]#errc::feature_not_supported# error code if
-the [code]#syclDevice# does not have [code]#aspect::usm_device_allocations#.
-The [code]#syclDevice# must either be contained by [code]#syclContext# or it
-must be a <<descendent-device>> of some device that is contained by that
-context, otherwise this function throws a synchronous [code]#exception# with
-the [code]#errc::invalid# error code.
+a@ Returns a pointer to the newly allocated memory, which is allocated on
+[code]#syclDevice#.  The allocation size is specified in bytes.  Throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if the [code]#syclDevice# does not have
+[code]#aspect::usm_device_allocations#.  The [code]#syclDevice# must either be
+contained by [code]#syclContext# or it must be a <<descendent-device>> of some
+device that is contained by that context, otherwise this function throws a
+synchronous [code]#exception# with the [code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10265,9 +10262,9 @@ T* sycl::malloc_device(size_t count,
                        const context& syclContext,
                        const property_list &propList = {})
 ----
-a@  Returns a pointer to the newly allocated memory on [code]#syclDevice# on
-success.  The allocation size is specified in number of elements of type
-[code]#T#.  Throws a synchronous [code]#exception# with the
+a@  Returns a pointer to the newly allocated memory, which is allocated on
+[code]#syclDevice#.  The allocation size is specified in number of elements of
+type [code]#T#.  Throws a synchronous [code]#exception# with the
 [code]#errc::feature_not_supported# error code if the [code]#syclDevice#
 does not have [code]#aspect::usm_device_allocations#.  The [code]#syclDevice#
 must either be contained by [code]#syclContext# or it must be a
@@ -10306,9 +10303,9 @@ sycl::aligned_alloc_device(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated memory on [code]#syclDevice#, where
-the memory is aligned according to [code]#alignment#.  The allocation size is
-specified in bytes.  Throws a synchronous [code]#exception# with the
+a@ Returns a pointer to the newly allocated memory, which is allocated on
+[code]#syclDevice#.  The allocation is specified in bytes and aligned according
+to [code]#alignment#.  Throws a synchronous [code]#exception# with the
 [code]#errc::feature_not_supported# error code if the [code]#syclDevice# does
 not have [code]#aspect::usm_device_allocations#.  The [code]#syclDevice# must
 either be contained by [code]#syclContext# or it must be a
@@ -10327,9 +10324,9 @@ sycl::aligned_alloc_device(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated memory on [code]#syclDevice#, where
-the memory is aligned according to [code]#alignment#.  The allocation size is
-specified in elements of type [code]#T#.  Throws a synchronous
+a@ Returns a pointer to the newly allocated memory, which is allocated on
+[code]#syclDevice#.  The allocation is specified in number of elements of type
+[code]#T# and aligned according to [code]#alignment#.  Throws a synchronous
 [code]#exception# with the [code]#errc::feature_not_supported# error code if
 the [code]#syclDevice# does not have [code]#aspect::usm_device_allocations#.
 The [code]#syclDevice# must either be contained by [code]#syclContext# or it
@@ -10366,14 +10363,14 @@ a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 
 ==== Host allocation functions
 
-The functions in <<table.usm.host.allocs>> allocate USM host memory.  On
-success, these functions return a pointer to the newly allocated memory, which
-must eventually be deallocated with [code]#sycl::free# in order to avoid a
-memory leak.  If there are not enough resources to allocate the requested
-memory, these functions return [code]#nullptr#.
+The functions in <<table.usm.host.allocs>> allocate host USM.  On success,
+these functions return a pointer to the newly allocated memory, which must
+eventually be deallocated with [code]#sycl::free# in order to avoid a memory
+leak.  If there are not enough resources to allocate the requested memory,
+these functions return [code]#nullptr#.
 
 [[table.usm.host.allocs]]
-.USM Host Memory Allocation Functions
+.Host USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Function @ Description
@@ -10384,9 +10381,9 @@ void* sycl::malloc_host(size_t numBytes,
                         const context& syclContext,
                         const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on success.  This
-allocation is specified in bytes.  Throws a synchronous [code]#exception# with
-the [code]#errc::feature_not_supported# error code if no device in
+a@ Returns a pointer to the newly allocated memory.  This allocation is
+specified in bytes.  Throws a synchronous [code]#exception# with the
+[code]#errc::feature_not_supported# error code if no device in
 [code]#syclContext# has [code]#aspect::usm_host_allocations#.
 
 a@
@@ -10397,11 +10394,10 @@ T* sycl::malloc_host(size_t count,
                      const context& syclContext,
                      const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on success.  This
-allocation is specified in number of elements of type [code]#T#.  Throws a
-synchronous [code]#exception# with the [code]#errc::feature_not_supported#
-error code if no device in [code]#syclContext# has
-[code]#aspect::usm_host_allocations#.
+a@ Returns a pointer to the newly allocated memory.  This allocation is
+specified in number of elements of type [code]#T#.  Throws a synchronous
+[code]#exception# with the [code]#errc::feature_not_supported# error code if no
+device in [code]#syclContext# has [code]#aspect::usm_host_allocations#.
 
 a@
 [source]
@@ -10431,11 +10427,11 @@ sycl::aligned_alloc_host(size_t alignment,
                          const context& syclContext,
                          const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on success.  This
-allocation is specified in bytes and aligned according to [code]#alignment#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if no device in
-[code]#syclContext# has [code]#aspect::usm_host_allocations#.
+a@ Returns a pointer to the newly allocated memory.  This allocation is
+specified in bytes and aligned according to [code]#alignment#.  Throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if no device in [code]#syclContext# has
+[code]#aspect::usm_host_allocations#.
 
 a@
 [source]
@@ -10447,8 +10443,8 @@ sycl::aligned_alloc_host(size_t alignment,
                          const context& syclContext,
                          const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on success.  This
-allocation is specified in elements of type [code]#T# and aligned according to
+a@ Returns a pointer to the newly allocated memory.  This allocation is
+specified in elements of type [code]#T# and aligned according to
 [code]#alignment#.  Throws a synchronous [code]#exception# with the
 [code]#errc::feature_not_supported# error code if no device in
 [code]#syclContext# has [code]#aspect::usm_host_allocations#.
@@ -10480,14 +10476,14 @@ a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
 
 ==== Shared allocation functions
 
-The functions in <<table.usm.shared.allocs>> allocate USM shared memory.  On
-success, these functions return a pointer to the newly allocated memory, which
-must eventually be deallocated with [code]#sycl::free# in order to avoid a
-memory leak.  If there are not enough resources to allocate the requested
-memory, these functions return [code]#nullptr#.
+The functions in <<table.usm.shared.allocs>> allocate shared USM.  On success,
+these functions return a pointer to the newly allocated memory, which must
+eventually be deallocated with [code]#sycl::free# in order to avoid a memory
+leak.  If there are not enough resources to allocate the requested memory,
+these functions return [code]#nullptr#.
 
 [[table.usm.shared.allocs]]
-.USM Shared Memory Allocation Functions
+.Shared USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Function @ Description
@@ -10499,8 +10495,8 @@ void* sycl::malloc_shared(size_t numBytes,
                           const context& syclContext,
                           const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated shared memory, which is allocated
-on [code]#syclDevice#.  This allocation is specified in bytes.  Throws a
+a@ Returns a pointer to the newly allocated memory, which is associated with
+[code]#syclDevice#.  This allocation is specified in bytes.  Throws a
 synchronous [code]#exception# with the [code]#errc::feature_not_supported#
 error code if the [code]#syclDevice# does not have
 [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice# must either be
@@ -10517,8 +10513,8 @@ T* sycl::malloc_shared(size_t count,
                        const context& syclContext,
                        const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated shared memory, which is allocated
-on [code]#syclDevice#.  This allocation is specified in number of elements of
+a@ Returns a pointer to the newly allocated memory, which is associated with
+[code]#syclDevice#.  This allocation is specified in number of elements of
 type [code]#T#.  Throws a synchronous [code]#exception# with the
 [code]#errc::feature_not_supported# error code if the [code]#syclDevice# does
 not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice# must
@@ -10558,8 +10554,8 @@ sycl::aligned_alloc_shared(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated shared memory, which is allocated
-on [code]#syclDevice#.  This allocation is specified in bytes and aligned
+a@ Returns a pointer to the newly allocated memory, which is associated with
+[code]#syclDevice#.  This allocation is specified in bytes and aligned
 according to [code]#alignment#.  Throws a synchronous [code]#exception# with
 the [code]#errc::feature_not_supported# error code if the [code]#syclDevice#
 does not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice#
@@ -10579,8 +10575,8 @@ sycl::aligned_alloc_shared(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated shared memory, which is allocated
-on [code]#syclDevice#.  This allocation is specified in number of elements of
+a@ Returns a pointer to the newly allocated memory, which is associated with
+[code]#syclDevice#.  This allocation is specified in number of elements of
 type [code]#T# and aligned aligned according to [code]#alignment#.  Throws a
 synchronous [code]#exception# with the [code]#errc::feature_not_supported#
 error code if the [code]#syclDevice# does not have
@@ -10619,7 +10615,7 @@ a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 ==== Parameterized allocation functions
 
 The functions in <<table.usm.param.allocs>> take a [code]#kind# parameter that
-specifies the type of USM memory to allocate.  When [code]#kind# is
+specifies the type of USM to allocate.  When [code]#kind# is
 [code]#usm::alloc::device#, then the allocation device must have
 [code]#aspect::usm_device_allocations#.  When [code]#kind# is
 [code]#usm::alloc::host#, at least one device in the allocation context must
@@ -10635,7 +10631,7 @@ a memory leak.  If there are not enough resources to allocate the requested
 memory, these functions return [code]#nullptr#.
 
 [[table.usm.param.allocs]]
-.USM Parameterized Allocation Functions
+.Parameterized USM Allocation Functions
 [width="100%",options="header",separator="@",cols="65%,35%"]
 |====
 @ Function @ Description
@@ -10648,9 +10644,9 @@ void *sycl::malloc(size_t numBytes,
                    usm::alloc kind,
                    const property_list &propList = {})
 ----
-a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
-This allocation size is specified in bytes.  The [code]#syclDevice# parameter
-is ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
+a@ Returns a pointer to the newly allocated memory of type [code]#kind#.  This
+allocation size is specified in bytes.  The [code]#syclDevice# parameter is
+ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
 [code]#usm::alloc::host#, [code]#syclDevice# must either be contained by
 [code]#syclContext# or it must be a <<descendent-device>> of some device that
 is contained by that context, otherwise this function throws a synchronous
@@ -10666,8 +10662,8 @@ T *sycl::malloc(size_t count,
                 usm::alloc kind,
                 const property_list &propList = {})
 ----
-a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
-This allocation size is specified in number of elements of type [code]#T#.  The
+a@ Returns a pointer to the newly allocated memory of type [code]#kind#.  This
+allocation size is specified in number of elements of type [code]#T#.  The
 [code]#syclDevice# parameter is ignored if [code]#kind# is
 [code]#usm::alloc::host#.  If [code]#kind# is not [code]#usm::alloc::host#,
 [code]#syclDevice# must either be contained by [code]#syclContext# or it must
@@ -10708,10 +10704,10 @@ void *sycl::aligned_alloc(size_t alignment,
                           usm::alloc kind,
                           const property_list &propList = {})
 ----
-a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
-This allocation is specified in bytes and is aligned according to
-[code]#alignment#.  The [code]#syclDevice# parameter is ignored if [code]#kind#
-is [code]#usm::alloc::host#.  If [code]#kind# is not [code]#usm::alloc::host#,
+a@ Returns a pointer to the newly allocated memory of type [code]#kind#.  This
+allocation is specified in bytes and is aligned according to [code]#alignment#.
+The [code]#syclDevice# parameter is ignored if [code]#kind# is
+[code]#usm::alloc::host#.  If [code]#kind# is not [code]#usm::alloc::host#,
 [code]#syclDevice# must either be contained by [code]#syclContext# or it must
 be a <<descendent-device>> of some device that is contained by that context,
 otherwise this function throws a synchronous [code]#exception# with the
@@ -10728,10 +10724,10 @@ T* sycl::aligned_alloc(size_t alignment,
                        usm::alloc kind,
                        const property_list &propList = {})
 ----
-a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
-This allocation is specified in number of elements of type [code]#T# and is
-aligned according to [code]#alignment#.  The [code]#syclDevice# parameter is
-ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
+a@ Returns a pointer to the newly allocated memory of type [code]#kind#.  This
+allocation is specified in number of elements of type [code]#T# and is aligned
+according to [code]#alignment#.  The [code]#syclDevice# parameter is ignored if
+[code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
 [code]#usm::alloc::host#, [code]#syclDevice# must either be contained by
 [code]#syclContext# or it must be a <<descendent-device>> of some device that
 is contained by that context, otherwise this function throws a synchronous
@@ -10824,13 +10820,13 @@ device get_pointer_device(const void *ptr,
                           const context &syclContext)
 ----
 a@ Returns the [code]#device# associated with the USM allocation.  If
-[code]#ptr# points within a USM device or shared allocation for the context
-[code]#syclContext#, returns the same device that was passed when allocating
-the memory.  If [code]#ptr# points within a USM host allocation for the context
-[code]#syclContext#, returns the first device in [code]#syclContext#.  Throws a
-synchronous [code]#exception# with the [code]#errc::invalid# error code if
-[code]#ptr# does not point within a valid USM allocation from
-[code]#syclContext#.
+[code]#ptr# points within a device USM allocation or a shared USM allocation
+for the context [code]#syclContext#, returns the same device that was passed
+when allocating the memory.  If [code]#ptr# points within a host USM allocation
+for the context [code]#syclContext#, returns the first device in
+[code]#syclContext#.  Throws a synchronous [code]#exception# with the
+[code]#errc::invalid# error code if [code]#ptr# does not point within a valid
+USM allocation from [code]#syclContext#.
 
 |====
 
@@ -13842,13 +13838,12 @@ a@
 void mem_advise(void* ptr, size_t numBytes, int advice)
 ----
 a@ Enqueues a command that provides information to the implementation about a
-region of USM memory starting at [code]#ptr# and extending for [code]#numBytes#
-bytes.  The [code]#ptr# must point within a USM allocation from the same
-context as the handler's queue, and the pointer must be accessible from the
-queue's device.  The values for [code]#advice# are vendor- or backend-specific,
-with the exception of the value [code]#0# which reverts the advice for
-[code]#ptr# to the default behavior.  For more detail on USM, please see
-<<sec:usm>>.
+region of USM starting at [code]#ptr# and extending for [code]#numBytes# bytes.
+The [code]#ptr# must point within a USM allocation from the same context as the
+handler's queue, and the pointer must be accessible from the queue's device.
+The values for [code]#advice# are vendor- or backend-specific, with the
+exception of the value [code]#0# which reverts the advice for [code]#ptr# to
+the default behavior.  For more detail on USM, please see <<sec:usm>>.
 
 |====
 

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9974,11 +9974,12 @@ There are no similar restrictions for dereferencing a USM pointer in a
 submitted to so long as the USM pointer is accessible on the host.
 ====
 
-Each type of USM memory allocation has different rules for where that memory is
-accessible.  Attempting to dereference a USM pointer in violation of these
-rules results in undefined behavior.  The explicit memory operation
-<<command, commands>> that take USM pointers have a similar restriction, and
-violating these restrictions results in undefined behavior.
+Each type of USM allocation has different rules for where that memory is
+accessible.  Attempting to dereference a USM pointer on the host or on a device
+in violation of these rules results in undefined behavior.  Passing a USM
+pointer to one of the explicit memory functions where the pointer is not
+accessible to the device generally results in undefined behavior.  See
+<<subsec:explicitmemory>> for the exact rules.
 
 Device allocations are used for explicitly managing device memory.
 Programmers directly allocate device memory and explicitly copy data

--- a/adoc/chapters/programming_interface.adoc
+++ b/adoc/chapters/programming_interface.adoc
@@ -9862,7 +9862,7 @@ the buffer programming model. USM enables:
   * A simpler programming model, by automatically migrating some allocations
     between SYCL devices and the host.
 
-To show the differences with example from <<sec:anatomy>>, the
+To show the differences with the example from <<sec:anatomy>>, the
 following source code example shows how shared memory can be used
 between host and device:
 
@@ -9872,7 +9872,7 @@ include::{code_dir}/usm_shared.cpp[lines=4..-1]
 ----
 
 By comparison, the following source code example uses less capable
-device memory, which requires explicit copy between the device and the
+device memory, which requires an explicit copy between the device and the
 host:
 [source,,linenums]
 ----
@@ -9919,14 +9919,16 @@ inside of a SYCL program:
 [source,,linenums]
 ----
 namespace sycl {
-  namespace usm {
-    enum class alloc : /* unspecified */ {
-      host,
-      device,
-      shared,
-      unknown
-    };
-  }
+namespace usm {
+
+enum class alloc : /* unspecified */ {
+  host,
+  device,
+  shared,
+  unknown
+};
+
+}
 }
 ----
 
@@ -9956,11 +9958,27 @@ The characteristics of USM allocations are summarized in
 |                                 Another [code]#device#    | Optional  | Another [code]#device#| Optional
 |====
 
-USM allocations are only guaranteed to be valid in the SYCL context in which
-they were created. The behavior of accessing a USM allocation in a different
-context from which it was created is undefined.  Attempting to access a kind
-of USM allocation that is not supported by the device results in undefined
-behavior.
+Each USM memory allocation has an associated SYCL context, and any access to
+that memory must use the same context.  Specifically, any
+<<sycl-kernel-function>> that dereferences a pointer to a USM memory allocation
+must be submitted to a <<queue>> that was constructed with the same context
+that was used to allocate that USM memory.  The explicit memory operation
+<<command, commands>> that take USM pointers have a similar restriction.  (See
+<<subsec:explicitmemory>> for details.)  Violations of these requirements
+result in undefined behavior.
+
+[NOTE]
+====
+There are no similar restrictions for dereferencing a USM pointer in a
+<<host-task>>.  This is legal regardless of which <<queue>> the host task was
+submitted to so long as the USM pointer is accessible on the host.
+====
+
+Each type of USM memory allocation has different rules for where that memory is
+accessible.  Attempting to dereference a USM pointer in violation of these
+rules results in undefined behavior.  The explicit memory operation
+<<command, commands>> that take USM pointers have a similar restriction, and
+violating these restrictions results in undefined behavior.
 
 Device allocations are used for explicitly managing device memory.
 Programmers directly allocate device memory and explicitly copy data
@@ -10050,10 +10068,11 @@ if system allocations are supported for use on the device, through
 [code]#aspect::usm_system_allocations#.
 
 
-
 === USM allocations
 
-USM provides several allocation functions.  These functions accept a [code]#property_list# parameter, which is provided for future extensibility.  This specification does not yet define any USM allocation properties.
+USM provides several allocation functions.  These functions accept a
+[code]#property_list# parameter, which is provided for future extensibility.
+The <<core-spec>> does not yet define any USM allocation properties.
 
 Some of the allocation functions take an explicit alignment parameter.  Like
 [code]#std::aligned_alloc#, these functions return [code]#nullptr# if the
@@ -10089,11 +10108,17 @@ a@ Pointer is suitably aligned for an object of type [code]#T# or it is aligned
 
 ==== {cpp} allocator interface
 
-USM provides an allocator class that aligns with the {cpp} allocator interface.  This is useful when
-using USM with things like {cpp} containers or routines like [code]#std::allocate_shared#.  However, due
-to how {cpp} library routines that use allocators tend to assume that any memory allocated by an allocator
-may be accessed on the host, the [code]#usm_allocator# class is not required to support
-allocating [code]#usm::alloc::device# allocations.
+SYCL defines an allocator class named [code]#usm_allocator# that satisfies the
+{cpp} named requirement [code]#Allocator#.  The [code]#AllocKind# template
+parameter can be either [code]#usm::alloc::host# or [code]#usm::alloc::shared#,
+causing the allocator to allocate either USM host or USM shared memory.
+
+[NOTE]
+====
+There is no specialization for [code]#usm::alloc::device# because an
+[code]#Allocator# is required to allocate memory that is accessible on the
+host.
+====
 
 The [code]#usm_allocator# class has a template argument [code]#Alignment#,
 which specifies the minimum alignment for memory that it allocates.  This
@@ -10121,10 +10146,10 @@ public:
   };
 
   usm_allocator() = delete;
-  usm_allocator(const context &ctxt,
-                const device &dev,
+  usm_allocator(const context &syclContext,
+                const device &syclDevice,
                 const property_list &propList = {});
-  usm_allocator(const queue &q,
+  usm_allocator(const queue &syclQueue,
                 const property_list &propList = {});
   usm_allocator(const usm_allocator &other);
   usm_allocator(usm_allocator &&) noexcept;
@@ -10165,42 +10190,48 @@ public:
 a@
 [source]
 ----
-usm_allocator(const context &ctxt,
-              const device &dev,
+usm_allocator(const context &syclContext,
+              const device &syclDevice,
               const property_list &propList = {})
 ----
 a@ Constructs a [code]#usm_allocator# instance that allocates USM memory for
-the provided context and device.  If [code]#AllocKind# is
-[code]#usm::alloc::host#, the [code]#dev# parameter is ignored.  For other
-values of [code]#AllocKind#, [code]#dev# must either be contained by
-[code]#ctxt# or it must be a <<descendent-device>> of some device that is
-contained by [code]#ctxt#, otherwise this constructor throws a synchronous
-[code]#exception# with the [code]#errc::invalid# error code.
+the provided context and device.
+
+If [code]#AllocKind# is [code]#usm::alloc::host#, this constructor throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if no device in [code]#syclContext# has
+[code]#aspect::usm_host_allocations#.  The [code]#syclDevice# is ignored for
+this allocation kind.
+
+If [code]#AllocKind# is [code]#usm::alloc::shared#, this constructor throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if the [code]#syclDevice# does not have
+[code]#aspect::usm_shared_allocations#.  The [code]#syclDevice# must either be
+contained by [code]#syclContext# or it must be a <<descendent-device>> of some
+device that is contained by that context, otherwise this constructor throws a
+synchronous [code]#exception# with the [code]#errc::invalid# error code.
 
 a@
 [source]
 ----
-usm_allocator(const queue &q,
+usm_allocator(const queue &syclQueue,
               const property_list &propList = {})
 ----
-a@ Constructs a [code]#usm_allocator# instance that allocates USM memory for
-the context and device from the provided [code]#queue#.
+a@ Simplified constructor form where [code]#syclQueue# provides the
+[code]#device# and [code]#context#.
 
 |====
 
-While the modern {cpp} [code]#usm_allocator# interface is sufficient for
-specifying USM allocations and deallocations, many programmers may prefer
-C-style [code]#malloc-influenced# APIs. As a convenience to
-programmers, [code]#malloc-style# APIs are also defined. Additionally,
-other utility functions are specified in the following sections to perform
-various operations such as memory copies and initializations as well as to
-provide performance hints.
-
-If the user attempts to allocate a kind of USM allocation on a device that does
-not support it, the allocation functions will throw a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code.
+SYCL also provides a number of free functions for allocating USM memory,
+similar to [code]#std::malloc#.
 
 ==== Device allocation functions
+
+The functions in <<table.usm.device.allocs>> allocate USM device memory.  On
+success, these functions return a pointer to the newly allocated memory, which
+must eventually be deallocated with [code]#sycl::free# in order to avoid a
+memory leak.  If there are not enough resources to allocate the requested
+memory, these functions return [code]#nullptr#.
 
 [[table.usm.device.allocs]]
 .USM Device Memory Allocation Functions
@@ -10216,17 +10247,13 @@ void* sycl::malloc_device(size_t numBytes,
                           const property_list &propList = {})
 ----
 a@ Returns a pointer to the newly allocated memory on [code]#syclDevice# on
-success.  The allocation size is specified in bytes.  This memory is not
-accessible on the host.  Memory allocated by [code]#sycl::malloc_device#
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.  Zero or more properties can be provided to the
-allocation function via an instance of [code]#property_list#.  Throws a
-synchronous [code]#exception# with the [code]#errc::feature_not_supported#
-error code if the [code]#syclDevice# does not have
-[code]#aspect::usm_device_allocations#.  The [code]#syclDevice# must either be
-contained by [code]#syclContext# or it must be a <<descendent-device>> of some
-device that is contained by that context, otherwise this function throws a
-synchronous [code]#exception# with the [code]#errc::invalid# error code.
+success.  The allocation size is specified in bytes.  Throws a synchronous
+[code]#exception# with the [code]#errc::feature_not_supported# error code if
+the [code]#syclDevice# does not have [code]#aspect::usm_device_allocations#.
+The [code]#syclDevice# must either be contained by [code]#syclContext# or it
+must be a <<descendent-device>> of some device that is contained by that
+context, otherwise this function throws a synchronous [code]#exception# with
+the [code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10239,12 +10266,7 @@ T* sycl::malloc_device(size_t count,
 ----
 a@  Returns a pointer to the newly allocated memory on [code]#syclDevice# on
 success.  The allocation size is specified in number of elements of type
-[code]#T#.  This memory is not accessible on the host.  Memory allocated
-by [code]#sycl::malloc_device# must be deallocated with
-[code]#sycl::free# to avoid memory leaks.  On failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
+[code]#T#.  Throws a synchronous [code]#exception# with the
 [code]#errc::feature_not_supported# error code if the [code]#syclDevice#
 does not have [code]#aspect::usm_device_allocations#.  The [code]#syclDevice#
 must either be contained by [code]#syclContext# or it must be a
@@ -10259,13 +10281,8 @@ void* sycl::malloc_device(size_t numBytes,
                           const queue& syclQueue,
                           const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#device#
-and [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_device_allocations#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
+[code]#context#.
 
 a@
 [source]
@@ -10275,13 +10292,8 @@ T* sycl::malloc_device(size_t count,
                        const queue& syclQueue,
                        const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#device#
-and [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_device_allocations#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
+[code]#context#.
 
 a@
 [source]
@@ -10293,17 +10305,12 @@ sycl::aligned_alloc_device(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated memory on
-the specified [code]#device# with [code]#alignment#-byte alignment on success.
-The allocation size is specified in bytes.  This memory is not accessible on
-the host.  Memory allocated by [code]#sycl::aligned_alloc_device# must be
-deallocated with [code]#sycl::free# to avoid memory leaks.  On failure, returns
-[code]#nullptr#.  Devices may only permit certain alignments.  Zero or more
-properties can be provided to the allocation function via an instance of
-[code]#property_list#.  Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the [code]#syclDevice#
-does not have [code]#aspect::usm_device_allocations#.  The [code]#syclDevice#
-must either be contained by [code]#syclContext# or it must be a
+a@ Returns a pointer to the newly allocated memory on [code]#syclDevice#, where
+the memory is aligned according to [code]#alignment#.  The allocation size is
+specified in bytes.  Throws a synchronous [code]#exception# with the
+[code]#errc::feature_not_supported# error code if the [code]#syclDevice# does
+not have [code]#aspect::usm_device_allocations#.  The [code]#syclDevice# must
+either be contained by [code]#syclContext# or it must be a
 <<descendent-device>> of some device that is contained by that context,
 otherwise this function throws a synchronous [code]#exception# with the
 [code]#errc::invalid# error code.
@@ -10319,20 +10326,15 @@ sycl::aligned_alloc_device(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated memory on
-the specified [code]#device# with [code]#alignment#-byte alignment on success.
-The allocation size is specified in elements of type [code]#T#.  This memory is
-not accessible on the host.  Memory allocated by
-[code]#sycl::aligned_alloc_device# must be deallocated with [code]#sycl::free#
-to avoid memory leaks.  On failure, returns [code]#nullptr#.  Devices may only
-permit certain alignments.  Zero or more properties can be provided to the
-allocation function via an instance of [code]#property_list#.  Throws a
-synchronous [code]#exception# with the [code]#errc::feature_not_supported#
-error code if the [code]#syclDevice# does not have
-[code]#aspect::usm_device_allocations#.  The [code]#syclDevice# must either be
-contained by [code]#syclContext# or it must be a <<descendent-device>> of some
-device that is contained by that context, otherwise this function throws a
-synchronous [code]#exception# with the [code]#errc::invalid# error code.
+a@ Returns a pointer to the newly allocated memory on [code]#syclDevice#, where
+the memory is aligned according to [code]#alignment#.  The allocation size is
+specified in elements of type [code]#T#.  Throws a synchronous
+[code]#exception# with the [code]#errc::feature_not_supported# error code if
+the [code]#syclDevice# does not have [code]#aspect::usm_device_allocations#.
+The [code]#syclDevice# must either be contained by [code]#syclContext# or it
+must be a <<descendent-device>> of some device that is contained by that
+context, otherwise this function throws a synchronous [code]#exception# with
+the [code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10343,13 +10345,8 @@ sycl::aligned_alloc_device(size_t alignment,
                            const queue& syclQueue,
                            const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#device#
-and [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_device_allocations#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
+[code]#context#.
 
 a@
 [source]
@@ -10361,17 +10358,18 @@ sycl::aligned_alloc_device(size_t alignment,
                            const queue& syclQueue,
                            const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#device#
-and [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_device_allocations#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
+[code]#context#.
 
 |====
 
 ==== Host allocation functions
+
+The functions in <<table.usm.host.allocs>> allocate USM host memory.  On
+success, these functions return a pointer to the newly allocated memory, which
+must eventually be deallocated with [code]#sycl::free# in order to avoid a
+memory leak.  If there are not enough resources to allocate the requested
+memory, these functions return [code]#nullptr#.
 
 [[table.usm.host.allocs]]
 .USM Host Memory Allocation Functions
@@ -10385,17 +10383,10 @@ void* sycl::malloc_host(size_t numBytes,
                         const context& syclContext,
                         const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on
-success. This allocation is specified in bytes. The allocation is
-accessible on the host and devices contained in the specified [code]#context#.
-Memory allocated by [code]#sycl::malloc_host# must be
-deallocated with [code]#sycl::free# to avoid memory leaks. On
-failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
+a@ Returns a pointer to the newly allocated host memory on success.  This
+allocation is specified in bytes.  Throws a synchronous [code]#exception# with
+the [code]#errc::feature_not_supported# error code if no device in
+[code]#syclContext# has [code]#aspect::usm_host_allocations#.
 
 a@
 [source]
@@ -10405,18 +10396,11 @@ T* sycl::malloc_host(size_t count,
                      const context& syclContext,
                      const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on
-success. This allocation is specified in number of elements of type [code]#T#.
-The allocation is accessible on the host and devices contained in the
-specified [code]#context#.
-Memory allocated by [code]#sycl::malloc_host# must be
-deallocated with [code]#sycl::free# to avoid memory leaks. On
-failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
+a@ Returns a pointer to the newly allocated host memory on success.  This
+allocation is specified in number of elements of type [code]#T#.  Throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if no device in [code]#syclContext# has
+[code]#aspect::usm_host_allocations#.
 
 a@
 [source]
@@ -10426,11 +10410,6 @@ void* sycl::malloc_host(size_t numBytes,
                         const property_list &propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
 
 a@
 [source]
@@ -10441,11 +10420,6 @@ T* sycl::malloc_host(size_t count,
                      const property_list &propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
 
 a@
 [source]
@@ -10456,18 +10430,11 @@ sycl::aligned_alloc_host(size_t alignment,
                          const context& syclContext,
                          const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on
-success. This allocation is specified in bytes and aligned to the specified
-alignment. The allocation is accessible on the host and devices contained
-in the specified [code]#context#.
-Memory allocated by [code]#sycl::malloc_host# must be
-deallocated with [code]#sycl::free# to avoid memory leaks. On
-failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
+a@ Returns a pointer to the newly allocated host memory on success.  This
+allocation is specified in bytes and aligned according to [code]#alignment#.
+Throws a synchronous [code]#exception# with the
+[code]#errc::feature_not_supported# error code if no device in
+[code]#syclContext# has [code]#aspect::usm_host_allocations#.
 
 a@
 [source]
@@ -10479,18 +10446,11 @@ sycl::aligned_alloc_host(size_t alignment,
                          const context& syclContext,
                          const property_list &propList = {})
 ----
-a@ Returns a pointer to the newly allocated host memory on
-success. This allocation is specified in elements of type [code]#T# and
-aligned to the specified alignment. The allocation is accessible on the
-host and devices contained in the specified [code]#context#.
-Memory allocated by [code]#sycl::malloc_host# must be
-deallocated with [code]#sycl::free# to avoid memory leaks. On
-failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
+a@ Returns a pointer to the newly allocated host memory on success.  This
+allocation is specified in elements of type [code]#T# and aligned according to
+[code]#alignment#.  Throws a synchronous [code]#exception# with the
+[code]#errc::feature_not_supported# error code if no device in
+[code]#syclContext# has [code]#aspect::usm_host_allocations#.
 
 a@
 [source]
@@ -10502,11 +10462,6 @@ sycl::aligned_alloc_host(size_t alignment,
                          const property_list &propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
 
 a@
 [source]
@@ -10519,15 +10474,16 @@ sycl::aligned_alloc_host(size_t alignment,
                          const property_list &propList = {})
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Only devices that have [code]#aspect::usm_host_allocations# may access the
-memory allocated by this function.  Attempting to access the memory from
-a device that does not have the aspect results in undefined behavior.
 
 |====
 
 ==== Shared allocation functions
+
+The functions in <<table.usm.shared.allocs>> allocate USM shared memory.  On
+success, these functions return a pointer to the newly allocated memory, which
+must eventually be deallocated with [code]#sycl::free# in order to avoid a
+memory leak.  If there are not enough resources to allocate the requested
+memory, these functions return [code]#nullptr#.
 
 [[table.usm.shared.allocs]]
 .USM Shared Memory Allocation Functions
@@ -10542,20 +10498,14 @@ void* sycl::malloc_shared(size_t numBytes,
                           const context& syclContext,
                           const property_list &propList = {})
 ----
-a@ Returns a shared allocation that is accessible on the host and
-on [code]#syclDevice#.
-This allocation is specified in bytes.  This memory
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the [code]#syclDevice#
-does not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice#
-must either be contained by [code]#syclContext# or it must be a
-<<descendent-device>> of some device that is contained by that context,
-otherwise this function throws a synchronous [code]#exception# with the
-[code]#errc::invalid# error code.
+a@ Returns a pointer to the newly allocated shared memory, which is allocated
+on [code]#syclDevice#.  This allocation is specified in bytes.  Throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if the [code]#syclDevice# does not have
+[code]#aspect::usm_shared_allocations#.  The [code]#syclDevice# must either be
+contained by [code]#syclContext# or it must be a <<descendent-device>> of some
+device that is contained by that context, otherwise this function throws a
+synchronous [code]#exception# with the [code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10566,17 +10516,12 @@ T* sycl::malloc_shared(size_t count,
                        const context& syclContext,
                        const property_list &propList = {})
 ----
-a@ Returns a shared allocation that is accessible on the host and
-on [code]#syclDevice#.
-This allocation is specified in number of elements of
-type [code]#T#. This memory must be deallocated with [code]#sycl::free# to avoid
-memory leaks.  On failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the [code]#syclDevice#
-does not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice#
-must either be contained by [code]#syclContext# or it must be a
+a@ Returns a pointer to the newly allocated shared memory, which is allocated
+on [code]#syclDevice#.  This allocation is specified in number of elements of
+type [code]#T#.  Throws a synchronous [code]#exception# with the
+[code]#errc::feature_not_supported# error code if the [code]#syclDevice# does
+not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice# must
+either be contained by [code]#syclContext# or it must be a
 <<descendent-device>> of some device that is contained by that context,
 otherwise this function throws a synchronous [code]#exception# with the
 [code]#errc::invalid# error code.
@@ -10590,11 +10535,6 @@ void* sycl::malloc_shared(size_t numBytes,
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_shared_allocations#.
 
 a@
 [source]
@@ -10606,11 +10546,6 @@ T* sycl::malloc_shared(size_t count,
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_shared_allocations#.
 
 a@
 [source]
@@ -10622,16 +10557,10 @@ sycl::aligned_alloc_shared(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a shared allocation that is accessible on the host and
-on [code]#syclDevice#.
-This allocation is specified in bytes and aligned to the
-specified alignment.  This memory
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the [code]#syclDevice#
+a@ Returns a pointer to the newly allocated shared memory, which is allocated
+on [code]#syclDevice#.  This allocation is specified in bytes and aligned
+according to [code]#alignment#.  Throws a synchronous [code]#exception# with
+the [code]#errc::feature_not_supported# error code if the [code]#syclDevice#
 does not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice#
 must either be contained by [code]#syclContext# or it must be a
 <<descendent-device>> of some device that is contained by that context,
@@ -10649,21 +10578,15 @@ sycl::aligned_alloc_shared(size_t alignment,
                            const context& syclContext,
                            const property_list &propList = {})
 ----
-a@ Returns a shared allocation that is accessible on the host and
-on [code]#syclDevice#.
-This allocation is specified in number of elements of type [code]#T# and aligned to the
-specified alignment.  This memory
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the [code]#syclDevice#
-does not have [code]#aspect::usm_shared_allocations#.  The [code]#syclDevice#
-must either be contained by [code]#syclContext# or it must be a
-<<descendent-device>> of some device that is contained by that context,
-otherwise this function throws a synchronous [code]#exception# with the
-[code]#errc::invalid# error code.
+a@ Returns a pointer to the newly allocated shared memory, which is allocated
+on [code]#syclDevice#.  This allocation is specified in number of elements of
+type [code]#T# and aligned aligned according to [code]#alignment#.  Throws a
+synchronous [code]#exception# with the [code]#errc::feature_not_supported#
+error code if the [code]#syclDevice# does not have
+[code]#aspect::usm_shared_allocations#.  The [code]#syclDevice# must either be
+contained by [code]#syclContext# or it must be a <<descendent-device>> of some
+device that is contained by that context, otherwise this function throws a
+synchronous [code]#exception# with the [code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10676,11 +10599,6 @@ sycl::aligned_alloc_shared(size_t alignment,
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_shared_allocations#.
 
 a@
 [source]
@@ -10694,29 +10612,26 @@ sycl::aligned_alloc_shared(size_t alignment,
 ----
 a@ Simplified form where [code]#syclQueue# provides the [code]#device# and
 [code]#context#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
-Throws a synchronous [code]#exception# with the
-[code]#errc::feature_not_supported# error code if the device
-does not have [code]#aspect::usm_shared_allocations#.
 
 |====
 
 ==== Parameterized allocation functions
 
-Device aspects define the set of legal allocation [code]#kind# in the
-parameterized allocation functions that follow.  [code]#usm:alloc::host#
-allocations require a device to have [code]#aspect::usm_host_allocations#.
-[code]#usm:alloc::device# allocations require a device to have
-[code]#aspect::usm_device_allocations#.
-[code]#usm:alloc::shared# allocations require a device to have
-[code]#aspect::usm_shared_allocations#.  Allocating a [code]#kind#
-on a device that doesn't have the appropriate aspect results in
-the allocation function throwing a synchronous [code]#exception#
-with the [code]#errc::feature_not_supported# error code, or 
-undefined behavior in the case of use of a host allocation on
-a device that doesn't have [code]#aspect::usm_host_allocations#.
+The functions in <<table.usm.param.allocs>> take a [code]#kind# parameter that
+specifies the type of USM memory to allocate.  When [code]#kind# is
+[code]#usm::alloc::device#, then the allocation device must have
+[code]#aspect::usm_device_allocations#.  When [code]#kind# is
+[code]#usm::alloc::host#, at least one device in the allocation context must
+have [code]#aspect::usm_host_allocations#.  When [code]#kind# is
+[code]#usm::alloc::shared#, the allocation device must have
+[code]#aspect::usm_shared_allocations#.  If these requirements are
+violated, the allocation function throws a synchronous [code]#exception# with
+the [code]#errc::feature_not_supported# error code.
 
+On success, these functions return a pointer to the newly allocated memory,
+which must eventually be deallocated with [code]#sycl::free# in order to avoid
+a memory leak.  If there are not enough resources to allocate the requested
+memory, these functions return [code]#nullptr#.
 
 [[table.usm.param.allocs]]
 .USM Parameterized Allocation Functions
@@ -10732,13 +10647,9 @@ void *sycl::malloc(size_t numBytes,
                    usm::alloc kind,
                    const property_list &propList = {})
 ----
-a@ Returns a [code]#kind# allocation.
-This allocation is specified in bytes. This memory
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.  The [code]#syclDevice# parameter is
-ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
+a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
+This allocation size is specified in bytes.  The [code]#syclDevice# parameter
+is ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
 [code]#usm::alloc::host#, [code]#syclDevice# must either be contained by
 [code]#syclContext# or it must be a <<descendent-device>> of some device that
 is contained by that context, otherwise this function throws a synchronous
@@ -10754,18 +10665,14 @@ T *sycl::malloc(size_t count,
                 usm::alloc kind,
                 const property_list &propList = {})
 ----
-a@ Returns a [code]#kind# allocation.
-This allocation is specified in number of elements of type [code]#T#.
-This memory must be deallocated with [code]#sycl::free# to avoid memory leaks.
-On failure, returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.  The [code]#syclDevice# parameter is
-ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
-[code]#usm::alloc::host#, [code]#syclDevice# must either be contained by
-[code]#syclContext# or it must be a <<descendent-device>> of some device that
-is contained by that context, otherwise this function throws a synchronous
-[code]#exception# with the [code]#errc::invalid# error code.
-
+a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
+This allocation size is specified in number of elements of type [code]#T#.  The
+[code]#syclDevice# parameter is ignored if [code]#kind# is
+[code]#usm::alloc::host#.  If [code]#kind# is not [code]#usm::alloc::host#,
+[code]#syclDevice# must either be contained by [code]#syclContext# or it must
+be a <<descendent-device>> of some device that is contained by that context,
+otherwise this function throws a synchronous [code]#exception# with the
+[code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10775,10 +10682,8 @@ void *sycl::malloc(size_t numBytes,
                    usm::alloc kind,
                    const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#context#
-and any necessary [code]#device#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#context# and any
+necessary [code]#device#.
 
 a@
 [source]
@@ -10789,10 +10694,8 @@ T *sycl::malloc(size_t count,
                 usm::alloc kind,
                 const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#context#
-and any necessary [code]#device#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#context# and any
+necessary [code]#device#.
 
 a@
 [source]
@@ -10804,18 +10707,14 @@ void *sycl::aligned_alloc(size_t alignment,
                           usm::alloc kind,
                           const property_list &propList = {})
 ----
-a@ Returns a [code]#kind# allocation.
-This allocation is specified in bytes and aligned to the
-specified alignment.  This memory
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.  The [code]#syclDevice# parameter is
-ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
-[code]#usm::alloc::host#, [code]#syclDevice# must either be contained by
-[code]#syclContext# or it must be a <<descendent-device>> of some device that
-is contained by that context, otherwise this function throws a synchronous
-[code]#exception# with the [code]#errc::invalid# error code.
+a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
+This allocation is specified in bytes and is aligned according to
+[code]#alignment#.  The [code]#syclDevice# parameter is ignored if [code]#kind#
+is [code]#usm::alloc::host#.  If [code]#kind# is not [code]#usm::alloc::host#,
+[code]#syclDevice# must either be contained by [code]#syclContext# or it must
+be a <<descendent-device>> of some device that is contained by that context,
+otherwise this function throws a synchronous [code]#exception# with the
+[code]#errc::invalid# error code.
 
 a@
 [source]
@@ -10828,13 +10727,9 @@ T* sycl::aligned_alloc(size_t alignment,
                        usm::alloc kind,
                        const property_list &propList = {})
 ----
-a@ Returns a [code]#kind# allocation.
-This allocation is specified in number of elements of type [code]#T# and aligned
-to the specified alignment.  This memory
-must be deallocated with [code]#sycl::free# to avoid memory leaks.  On failure,
-returns [code]#nullptr#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.  The [code]#syclDevice# parameter is
+a@ Returns a pointer to a newly allocated shared memory of type [code]#kind#.
+This allocation is specified in number of elements of type [code]#T# and is
+aligned according to [code]#alignment#.  The [code]#syclDevice# parameter is
 ignored if [code]#kind# is [code]#usm::alloc::host#.  If [code]#kind# is not
 [code]#usm::alloc::host#, [code]#syclDevice# must either be contained by
 [code]#syclContext# or it must be a <<descendent-device>> of some device that
@@ -10850,10 +10745,8 @@ void *sycl::aligned_alloc(size_t alignment,
                           usm::alloc kind,
                           const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#context#
-and any necessary [code]#device#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#context# and any
+necessary [code]#device#.
 
 a@
 [source]
@@ -10865,10 +10758,8 @@ T* sycl::aligned_alloc(size_t alignment,
                        usm::alloc kind,
                        const property_list &propList = {})
 ----
-a@ Simplified form where [code]#syclQueue# provides the [code]#context#
-and any necessary [code]#device#.
-Zero or more properties can be provided to the allocation function
-via an instance of [code]#property_list#.
+a@ Simplified form where [code]#syclQueue# provides the [code]#context# and any
+necessary [code]#device#.
 
 |====
 
@@ -10887,9 +10778,9 @@ void sycl::free(void* ptr, const context& syclContext)
 ----
 a@ Frees an allocation.  The memory pointed to by [code]#ptr# must have been
 allocated using one of the USM allocation routines.  [code]#syclContext# must
-be the same [code]#context# that was used to allocate the memory.  The memory 
-is freed without waiting for <<command, commands>> operating on it to be 
-completed.  If <<command, commands>> that use this memory are in-progress or 
+be the same [code]#context# that was used to allocate the memory.  The memory
+is freed without waiting for <<command, commands>> operating on it to be
+completed.  If <<command, commands>> that use this memory are in-progress or
 are enqueued the behavior is undefined.
 
 a@
@@ -13740,7 +13631,7 @@ When an accessor is used as a parameter to one of these explicit copy
 operations, the target must be either [code]#target::device# or
 [code]#target::constant_buffer#.
 
-When accessors are both the origin and the destination,
+When accessors are both the source and the destination,
 the operation is executed on objects controlled by the SYCL runtime.
 The SYCL runtime is allowed to not perform an explicit in-copy operation
 if a different path to update the data is available according to
@@ -13751,7 +13642,7 @@ by the SYCL runtime, or on the host in a pointer controlled by the
 SYCL runtime.  The SYCL runtime will ensure that data is copied to the destination
 once the <<command-group>> has completed execution.
 
-Whenever a host pointer is used as either the host or the destination of these
+Whenever a host pointer is used as either the source or the destination of these
 explicit memory operations, it is the responsibility
 of the user for that pointer to have at least as much memory allocated as
 the accessor is giving access to, e.g: if an accessor accesses a range
@@ -13786,8 +13677,8 @@ void copy(accessor<SrcT, SrcDims,
 ----
 a@ Copies the contents of the memory object accessed by
 [code]#src# into the memory pointed to by [code]#dest#.
-[code]#dest# must have at least as many bytes as the
-range accessed by [code]#src#.
+[code]#dest# must be a host pointer and must have at least
+as many bytes as the range accessed by [code]#src#.
 
 a@
 [source]
@@ -13802,8 +13693,8 @@ void copy(std::shared_ptr<SrcT> src,
 ----
 a@ Copies the contents of the memory pointed to by [code]#src#
 into the memory object accessed by [code]#dest#.
-[code]#src# must have at least as many bytes as the
-range accessed by [code]#dest#.
+[code]#src# must be a host pointer and must have at least
+as many bytes as the range accessed by [code]#dest#.
 
 a@
 [source]
@@ -13818,8 +13709,8 @@ void copy(accessor<SrcT, SrcDims,
 ----
 a@ Copies the contents of the memory object accessed by
 [code]#src# into the memory pointed to by [code]#dest#.
-[code]#dest# must have at least as many bytes as the
-range accessed by [code]#src#.
+[code]#dest# must be a host pointer and must have at least
+as many bytes as the range accessed by [code]#src#.
 
 a@
 [source]
@@ -13834,8 +13725,8 @@ void copy(const SrcT * src,
 ----
 a@ Copies the contents of the memory pointed to by [code]#src#
 into the memory object accessed by [code]#dest#.
-[code]#src# must have at least as many bytes as the
-range accessed by [code]#dest#.
+[code]#src# must be a host pointer and must have at least
+as many bytes as the range accessed by [code]#dest#.
 
 a@
 [source]
@@ -13891,11 +13782,12 @@ a@
 ----
 void memcpy(void* dest, const void* src, size_t numBytes)
 ----
-a@ Copies [code]#numBytes# of data from the pointer 
-[code]#src# to the pointer [code]#dest#.
-Both [code]#dest# and [code]#src# may be either
-host or USM pointers.
-For more detail on USM, please see <<sec:usm>>.
+a@ Copies [code]#numBytes# of data from the pointer [code]#src# to the pointer
+[code]#dest#.  The [code]#dest# and [code]#src# parameters must each either be
+a host pointer or a pointer within a USM allocation that is accessible on the
+handler's device.  If a pointer is to a USM allocation, that allocation must
+have been created from the same context as the handler's queue.  For more
+detail on USM, please see <<sec:usm>>.
 
 a@
 [source]
@@ -13903,10 +13795,11 @@ a@
 template <typename T>
 void copy(const T* src, T* dest, size_t count)
 ----
-a@ Copies [code]#count# elements of type [code]#T# from the pointer
-[code]#src# to the pointer [code]#dest#.
-Both [code]#dest# and [code]#src# may be either
-host or USM pointers.
+a@ Copies [code]#count# elements of type [code]#T# from the pointer [code]#src#
+to the pointer [code]#dest#.  The [code]#dest# and [code]#src# parameters must
+each either be a host pointer or a pointer within a USM allocation that is
+accessible on the handler's device.  If a pointer is to a USM allocation, that
+allocation must have been created from the same context as the handler's queue.
 For more detail on USM, please see <<sec:usm>>.
 
 a@
@@ -13915,9 +13808,10 @@ a@
 void memset(void* ptr, int value, size_t numBytes)
 ----
 a@ Fills [code]#numBytes# bytes of memory beginning at address [code]#ptr#
-with [code]#value#. [code]#ptr# must be a USM allocation.
-Note that [code]#value# is interpreted as an
-[code]#unsigned char#. For more detail on USM, please see <<sec:usm>>.
+with [code]#value#.  The [code]#ptr# must point within a USM allocation from
+the same context as the handler's queue, and the pointer must be accessible
+from the queue's device.  Note that [code]#value# is interpreted as an
+[code]#unsigned char#.  For more detail on USM, please see <<sec:usm>>.
 
 a@
 [source]
@@ -13925,31 +13819,35 @@ a@
 template <typename T>
 void fill(void* ptr, const T& pattern, size_t count)
 ----
-a@ Replicates the provided [code]#pattern# into the target
-USM pointer [code]#ptr#. [code]#ptr# must be a USM allocation.
-[code]#pattern# is filled [code]#count#
-times.
-For more detail on USM, please see <<sec:usm>>.
+a@ Replicates the provided [code]#pattern# into the memory at address
+[code]#ptr#.  The [code]#ptr# must point within a USM allocation from the same
+context as the handler's queue, and the pointer must be accessible from the
+queue's device.  The [code]#pattern# is filled [code]#count# times.  For more
+detail on USM, please see <<sec:usm>>.
 
 a@
 [source]
 ----
 void prefetch(void* ptr, size_t numBytes)
 ----
-a@ Enqueues a prefetch of [code]#num_bytes# of data pointed to by
-the USM pointer [code]#ptr#.
-For more detail on USM, please see <<sec:usm>>.
+a@ Enqueues a prefetch of [code]#num_bytes# of data starting at address
+[code]#ptr#.  The [code]#ptr# must point within a USM allocation from the same
+context as the handler's queue, and the pointer must be accessible from the
+queue's device.  For more detail on USM, please see <<sec:usm>>.
 
 a@
 [source]
 ----
 void mem_advise(void* ptr, size_t numBytes, int advice)
 ----
-a@ Provides information to the SYCL runtime about the USM allocation
-at [code]#ptr#. Acceptable values of [code]#advice# are
-device-defined.  A value of [code]#0# reverts the advice for
-[code]#ptr# to the default behavior.
-For more detail on USM, please see <<sec:usm>>.
+a@ Enqueues a command that provides information to the implementation about a
+region of USM memory starting at [code]#ptr# and extending for [code]#numBytes#
+bytes.  The [code]#ptr# must point within a USM allocation from the same
+context as the handler's queue, and the pointer must be accessible from the
+queue's device.  The values for [code]#advice# are vendor- or backend-specific,
+with the exception of the value [code]#0# which reverts the advice for
+[code]#ptr# to the default behavior.  For more detail on USM, please see
+<<sec:usm>>.
 
 |====
 


### PR DESCRIPTION
Various clarifications about the meaning of the context that is used
to allocate USM memory:

* If a kernel dereferences a USM pointer, that USM allocation must have
  the same context as the queue to which the kernel is submitted.

* A USM pointer that is passed to an explicit memory operation command
  must come from a USM allocation that uses the same context as the
  queue to which the command is submitted.

* A USM pointer that is passed to an explicit memory operation command
  must be accessible on the queue's device.

* For the explicit copy operation commands that take both an accessor
  and a pointer, clarify that the pointer must be a host pointer.

* When allocating USM "host" memory, at least one of the devices in
  the context must support USM "host" memory.

I also cleaned up the descriptions of some of the USM allocation
functions by moving some common wording to the corresponding section
preamble.

Closes #184